### PR TITLE
Visual updates, fix skip mode (NaN mode 1)

### DIFF
--- a/sample_config.ini
+++ b/sample_config.ini
@@ -23,7 +23,7 @@ bits=8
 [Advanced]
 ; alternative length constant (based on the t value itself), seconds is ignored if not 0
 tLength=0
-; the amount of workers that will be working simultaneously (to speed up the process), set to 1 for expressions with a reverb function (or those that dont use t)
+; the amount of workers that will be working simultaneously (to speed up the process), set to 1 for expressions with a reverb function (or those that dont use a fake t). can be "auto"
 workers=1
 [Misc]
 ; 0.1 - report every 10th second, 1 - report every second, 2 - report every half second, etc

--- a/worker.js
+++ b/worker.js
@@ -1,16 +1,11 @@
 const {
 	Worker, isMainThread, parentPort, workerData
 } = require('worker_threads');
-if(isMainThread) {
-	console.log('you are doing it wrong');
+if(isMainThread) { // Safegaurd against running this file instead of cabbr.js
+	console.log('You\'re doing it wrong: Open cabbr.js instead');
 	process.exit(0);
 } else {
-	var sampleRate = workerData.sampleRate;
-	var seconds = workerData.seconds;
-	var reportEvery = workerData.reportEvery;
-	var stereo = workerData.stereo;
-	var expr = workerData.expr;
-	var type = workerData.type;
+	var {sampleRate, reportEvery, stereo, expr, type, skipNaNs} = workerData;
 	var fakeWindow = {};
 	var mathNames = Object.getOwnPropertyNames(Math);
 	var mathProps = mathNames.map((prop) => {
@@ -25,7 +20,14 @@ if(isMainThread) {
 	func(0);
 	(async()=>{
 		for (var t = range[0]; t<range[1]; t++) {
-			var res = func(Number(t));
+			if(reportEvery > 0 && t%Math.round(sampleRate/reportEvery)==stereo) parentPort.postMessage(process.argv[4]+';'+((t-range[0])/(range[1]-range[0])*100)+'%');
+			var res = NaN;
+			try {
+				res = +func(Number(t))
+			} catch (error) {
+				console.log('Error: %s',error.message);
+			}
+			if(skipNaNs && isNaN(res)) continue;
 			if(stereo) {
 				switch(type) {
 					case 0:
@@ -55,11 +57,10 @@ if(isMainThread) {
 						break;
 				}
 			}
-			if(reportEvery > 0 && t%Math.round(sampleRate/reportEvery)==stereo) parentPort.postMessage(process.argv[4]+';'+((t-range[0])/(range[1]-range[0])*100)+'%');
 		}
-		console.log('Worker #'+process.argv[4]+' done! Transferring '+prettyPrintSize((range[1]-range[0])*(stereo+1))+' of data...');
 		parentPort.postMessage([parseInt(process.argv[4])-1,data]);
-		console.log('Data transfer from worker #'+process.argv[4]+' completed!');
+		console.log('Worker #'+process.argv[4]+' is done!\x1b[1F');
+		parentPort.postMessage(['Done',parseInt(process.argv[4])-1])
 	})();
 }
 


### PR DESCRIPTION
Skip mode used to ~~halt the renderer at the NaN handling stage~~ *works fine, but I changed it from polynomial to linear time*. Now if skip mode is used, NaN samples are actually skipped.

Also adds a progress bar, worker status indicators, and an "auto" option for the worker count.

![image](https://github.com/cabfile/cabbr/assets/105890603/ad73b7f4-9ba4-4d43-9423-74db494d954d)