### PR TITLE
A2: Progress bar, worker count, O(n) NaN mode 1, "max" worker option.

### DIFF
--- a/sample_config.ini
+++ b/sample_config.ini
@@ -1,12 +1,17 @@
 [General]
 ; 0 = bytebeat, 1 = signed bytebeat, 2 = floatbeat
 type=0
+
 ; whether the expression returns an array that contains data on left and right channels
 stereo=false
+
 ; how long should the output be
 seconds=30
+
 ; original sample rate
 sampleRate=8000
+
+
 [Quality]
 ; quality upscale multiplier
 ; examples:
@@ -14,19 +19,28 @@ sampleRate=8000
 ; 5.5125 = 8000 -> 44100
 ; 1.378125 = 8000 -> 11025, 32000 -> 44100
 upscale=1
+
 ; values higher than 0 enable resampling (make sure to install the wave-resampler package), this is the target sample rate (upscale is not ignored)
 resample=0
+
 ; can be either point, linear, cubic or sinc (point is generally the best, for sine waves and such use linear)
 resampleMethod=point
+
 ; the amount of bits in the result, currently only 8 and 16 are supported (16 is slightly broken)
 bits=8
+
+
 [Advanced]
 ; alternative length constant (based on the t value itself), seconds is ignored if not 0
 tLength=0
-; the amount of workers that will be working simultaneously (to speed up the process), set to 1 for expressions with a reverb function (or those that dont use a fake t). can be "auto"
+
+; the amount of workers that will be working simultaneously (to speed up the process), set to 1 for expressions with a reverb function (or those that dont use a fake t). Set to "max" to use the number of CPU cores availible
 workers=1
+
+
 [Misc]
 ; 0.1 - report every 10th second, 1 - report every second, 2 - report every half second, etc
 reportEvery=0.1
+
 ; what to do with invalid (NaN) samples: 0 - nothing (set to 0), 1 - skip, 2 - stop the audio, 3 - repeat last sample
 invalidSamples=0

--- a/sample_config.ini
+++ b/sample_config.ini
@@ -23,7 +23,7 @@ bits=8
 [Advanced]
 ; alternative length constant (based on the t value itself), seconds is ignored if not 0
 tLength=0
-; the amount of workers that will be working simultaneously (to speed up the process), set to 1 for expressions with a reverb function (or those that dont use t)
+; the amount of workers that will be working simultaneously (to speed up the process), set to 1 for expressions with a reverb function (or those that dont use a fake t). can be "auto"
 workers=1
 [Misc]
 ; 0.1 - report every 10th second, 1 - report every second, 2 - report every half second, etc

--- a/worker.js
+++ b/worker.js
@@ -1,5 +1,5 @@
 const {
-	Worker, isMainThread, parentPort, workerData
+	isMainThread, parentPort, workerData
 } = require('worker_threads');
 if(isMainThread) { // Safegaurd against running this file instead of cabbr.js
 	console.log('You\'re doing it wrong: Open cabbr.js instead');
@@ -22,9 +22,9 @@ if(isMainThread) { // Safegaurd against running this file instead of cabbr.js
 		for (var t = range[0]; t<range[1]; t++) {
 			var res = NaN;
 			try {
-				res = +func(Number(t))
+				res = +func(+t)
 			} catch (error) {
-				console.log('Error: %s',error.message);
+				console.log('Error at %d: %s\x1b[1F',t,error.message);
 			}
 			if(skipNaNs && isNaN(res)) continue;
 			if(stereo) {
@@ -59,8 +59,7 @@ if(isMainThread) { // Safegaurd against running this file instead of cabbr.js
 			if(reportEvery > 0 && t%Math.round(sampleRate/reportEvery)==stereo) parentPort.postMessage(process.argv[4]+';'+((t-range[0])/(range[1]-range[0])*100)+'%');
 		}
 		parentPort.postMessage([parseInt(process.argv[4])-1,data]);
-		console.log('Worker #'+process.argv[4]+' is done!\x1b[1F');
-		parentPort.postMessage(['Done',parseInt(process.argv[4])-1])
+		console.log('Worker #'+process.argv[4]+' is done! (%s)\x1b[1F',prettyPrintSize(data.length));
 	})();
 }
 

--- a/worker.js
+++ b/worker.js
@@ -20,7 +20,6 @@ if(isMainThread) { // Safegaurd against running this file instead of cabbr.js
 	func(0);
 	(async()=>{
 		for (var t = range[0]; t<range[1]; t++) {
-			if(reportEvery > 0 && t%Math.round(sampleRate/reportEvery)==stereo) parentPort.postMessage(process.argv[4]+';'+((t-range[0])/(range[1]-range[0])*100)+'%');
 			var res = NaN;
 			try {
 				res = +func(Number(t))
@@ -57,6 +56,7 @@ if(isMainThread) { // Safegaurd against running this file instead of cabbr.js
 						break;
 				}
 			}
+			if(reportEvery > 0 && t%Math.round(sampleRate/reportEvery)==stereo) parentPort.postMessage(process.argv[4]+';'+((t-range[0])/(range[1]-range[0])*100)+'%');
 		}
 		parentPort.postMessage([parseInt(process.argv[4])-1,data]);
 		console.log('Worker #'+process.argv[4]+' is done!\x1b[1F');

--- a/worker.js
+++ b/worker.js
@@ -1,16 +1,11 @@
 const {
 	Worker, isMainThread, parentPort, workerData
 } = require('worker_threads');
-if(isMainThread) {
-	console.log('you are doing it wrong');
+if(isMainThread) { // Safegaurd against running this file instead of cabbr.js
+	console.log('You\'re doing it wrong: Open cabbr.js instead');
 	process.exit(0);
 } else {
-	var sampleRate = workerData.sampleRate;
-	var seconds = workerData.seconds;
-	var reportEvery = workerData.reportEvery;
-	var stereo = workerData.stereo;
-	var expr = workerData.expr;
-	var type = workerData.type;
+	var {sampleRate, reportEvery, stereo, expr, type, skipNaNs} = workerData;
 	var fakeWindow = {};
 	var mathNames = Object.getOwnPropertyNames(Math);
 	var mathProps = mathNames.map((prop) => {
@@ -25,7 +20,14 @@ if(isMainThread) {
 	func(0);
 	(async()=>{
 		for (var t = range[0]; t<range[1]; t++) {
-			var res = func(Number(t));
+			if(reportEvery > 0 && t%Math.round(sampleRate/reportEvery)==stereo) parentPort.postMessage(process.argv[4]+';'+((t-range[0])/(range[1]-range[0])*100)+'%');
+			var res = NaN;
+			try {
+				res = +func(Number(t))
+			} catch (error) {
+				console.log('Error: %s',error.message);
+			}
+			if(skipNaNs && isNaN(res)) continue;
 			if(stereo) {
 				switch(type) {
 					case 0:
@@ -55,11 +57,10 @@ if(isMainThread) {
 						break;
 				}
 			}
-			if(reportEvery > 0 && t%Math.round(sampleRate/reportEvery)==stereo) parentPort.postMessage(process.argv[4]+';'+((t-range[0])/(range[1]-range[0])*100)+'%');
 		}
-		console.log('Worker #'+process.argv[4]+' done! Transferring '+prettyPrintSize((range[1]-range[0])*(stereo+1))+' of data...');
 		parentPort.postMessage([parseInt(process.argv[4])-1,data]);
-		console.log('Data transfer from worker #'+process.argv[4]+' completed!');
+		console.log('Worker #'+process.argv[4]+' is done!\x1b[1F');
+		parentPort.postMessage(['Done',parseInt(process.argv[4])-1])
 	})();
 }
 


### PR DESCRIPTION
Changes:

+ Progress bar added, instead of just "Done: %d".
+ Now the number of workers completed is shown.
+ NaN mode 1 used to be done in the post-processing stage, which would either use twice as much memory or take O(n^2)**\*** calculations for *n* samples (in the worst case of all NaNs). This was changed to being moved to the workers, which had little effect on the time needed for the processing stage, and allowed for O(n) calculations for n samples. This dramatically sped up skip mode's functionality for NaN-heavy codes like "sparta remix is in my head now"
+ Instead of an explicit count, the worker count can be "max". This sets the worker count to the number of CPU cores available (via `require('os').availableParallelism()`.)

This is an evolved version of pull-request #1 .

\* Might be closer to O(n log n)